### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,22 @@ A layout very similar to [MosaicUI](https://github.com/betzerra/MosaicUI) that u
 
 ![Landscape on iPad](http://www.betzerra.com.ar/wp-content/uploads/2013/02/Photo-Feb-17-6-29-14-PM.png)
 
-##Instructions
+## Instructions
 - Import all the files from Libs/MosaicLayout folder.
 - Add a UICollectionView view, change its layout to "Custom" and set its class to "MosaicLayout".
 - Implement UICollectionView's delegates.
 - Implement **MosaicLayoutDelegate** protocol.
 
-##MosaicLayoutDelegate
+## MosaicLayoutDelegate
 ```objc
 -(float)collectionView:(UICollectionView *)collectionView relativeHeightForItemAtIndexPath:(NSIndexPath *)indexPath;
 -(BOOL)collectionView:(UICollectionView *)collectionView isDoubleColumnAtIndexPath:(NSIndexPath *)indexPath;
 -(NSUInteger)numberOfColumnsInCollectionView:(UICollectionView *)collectionView;
 ```
 
-##Requirements
+## Requirements
 - iOS 6
 - ARC
 
-##License
+## License
 This project is under MIT License. See LICENSE file for more information.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
